### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+**/.git
+.gitattributes
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.9 as build-stage
+# Install build dependencies
+RUN apk --no-cache \
+    add --virtual build-dependencies \
+    gcc \
+    musl-dev \
+    make
+# Prepare workspace
+WORKDIR /usr/local/src/gzinject
+COPY . .
+# Compile and install
+RUN ./configure --prefix=/opt/gzinject
+RUN make \
+    && make install
+
+# Final image
+FROM alpine:3.9
+COPY --from=build-stage /opt/gzinject /usr/local
+CMD ["/bin/sh"]

--- a/Makefile.in
+++ b/Makefile.in
@@ -19,7 +19,7 @@ distclean	: clean
 	rm -f Makefile
 
 install		:
-	install -p -D --target-directory=$(bindir) $(PROGNAME)
+	install -p -D -t $(bindir) $(PROGNAME)
 
 $(PROGNAME) : $(SRC)
 	$(CC) $(CFLAGS) $(LDFLAGS) $^ $(LIBS) -o $@


### PR DESCRIPTION
# Add Dockerfile - Merge Request
This merge request adds a dockerfile to the repository. Using this it is possible to build an image with e.g. `docker build --tag gzinject .` if docker is installed on the machine. This image can be used to run a container with `docker run --interactive --tty --rm gzinject`. From there it is possible to easily clone, build and run gz for example.

## Background
This is mostly to align with [my PR in glankk/n64](https://github.com/glankk/n64/pull/6) and [my PR in glankk/gz](https://github.com/glankk/gz/pull/25).

## Suggested Solution
Utilize a platform as a service using operating-system-level virtualization with containers. It does not matter which OS and which configuration the usage machine has. As long as it can run the container it will have a predictable and isolated environment. [Docker](https://www.docker.com/resources/what-container) is such a solution.