### PR TITLE
Add support for multiple gzi files.

### DIFF
--- a/src/gzinject.h
+++ b/src/gzinject.h
@@ -21,6 +21,12 @@ typedef enum{
     FILE_NORMAL
 }filetype_t;
 
+typedef struct patch_list patch_list_t;
+struct patch_list {
+    const char   *filename;
+    patch_list_t *next;
+};
+
  uint16_t be16(const uint8_t *p);
 
  uint32_t be32(const uint8_t *p);


### PR DESCRIPTION
Each provided patch file is stored in a linked list, and the entire list is processed during wad packing. Reduces clutter caused by requiring a unique patch file for each possible combination of desired patches.