### PR TITLE
Resolve errors and warning

### DIFF
--- a/src/doltool.c
+++ b/src/doltool.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include <sys/stat.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "doltool.h"

--- a/src/gzinject.c
+++ b/src/gzinject.c
@@ -810,7 +810,7 @@ static int do_pack() {
                         break;
                     }
                 }
-                if(imetpos!=-1){
+                if(imetpos!=(uint16_t)-1){
                     uint16_t count = 0;
                     size_t cnamelen = strlen(channelname);
                     char namebuf[40] = {0};

--- a/src/gzinject.c
+++ b/src/gzinject.c
@@ -259,7 +259,7 @@ static int do_extract() {
 
     uint8_t *data = (uint8_t*)malloc(sbuffer.st_size);
     if(!data){
-        fprintf(stderr,"Could not allocate %ld bytes for wad\n",sbuffer.st_size);
+        fprintf(stderr,"Could not allocate %lld bytes for wad\n",sbuffer.st_size);
         return 0;
     }
     FILE *wadfile = fopen(wad, "rb");
@@ -659,7 +659,7 @@ static int do_pack() {
         filesizes[i] = addpadding(sbuffer.st_size,16);
         fileptrs[i] = calloc(filesizes[i],1);
         if(!fileptrs[i]){
-            fprintf(stderr,"Could not allocate %ld bytes for %s\n",sbuffer.st_size,cfname);
+            fprintf(stderr,"Could not allocate %lld bytes for %s\n",sbuffer.st_size,cfname);
             goto error;
         }
         infile = fopen(cfname,"rb");
@@ -1006,7 +1006,7 @@ void romc(){
     }
     uint8_t *comp = malloc(sbuffer.st_size);
     if(!comp){
-        printf("Could not alloc %ld bytes\n",sbuffer.st_size);
+        printf("Could not alloc %lld bytes\n",sbuffer.st_size);
     }
     fread(comp,1,sbuffer.st_size,inrom);
     fclose(inrom);


### PR DESCRIPTION
I replaced "malloc.h" with "stdlib.h" because "malloc.h" is depreciated and for me, on MacOS doesn't exist. 

For some printf, i replaced "ld" with "lld" to print "long long".
A last warning, one unsigned integer is compared with -1, i cast -1 because gcc indicate to me that is always true. 