### PR TITLE
Add support for installing with DESTDIR

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -27,7 +27,7 @@ distclean	:	clean
 	rm -f Makefile
 
 install		:	$(PROGNAME)
-	$(INSTALL) -p -D --target-directory=$(bindir) $(PROGNAME)
+	$(INSTALL) -p -D --target-directory=$(DESTDIR)$(bindir) $(PROGNAME)
 
 $(PROGNAME)	:	$(COBJ)
 	$(LD) $(LDFLAGS) $^ -o $@ $(LIBS) 


### PR DESCRIPTION
Adds support for the DESTDIR makefile variable used when creating packages. Fixes the missing gzinject binary from the practicerom.com package.