### PR TITLE
Fix Mac Support

### DIFF
--- a/src/doltool.c
+++ b/src/doltool.c
@@ -1,6 +1,9 @@
 #include <stdio.h>
 #include <sys/stat.h>
-#include <malloc.h>
+#if defined(__MACH__)
+  #include <stdlib.h>
+#else 
+  #include <malloc.h>
 #include <string.h>
 
 #include "doltool.h"


### PR DESCRIPTION
Fixes "malloc.h not found" on OS X.

https://github.com/HackerN64/HackerOoT/issues/83